### PR TITLE
Output the url where the link is located

### DIFF
--- a/src/crawling.rs
+++ b/src/crawling.rs
@@ -47,15 +47,15 @@ const CRAWL_THREADS: i32 = 10;
 /// `url_s` channel.
 fn crawl_worker_thread(
     domain: &str,
-    url_s: Sender<String>,
-    url_r: Receiver<String>,
+    url_s: Sender<(String, String)>,
+    url_r: Receiver<(String, String)>,
     visited: Arc<Mutex<HashSet<String>>>,
     active_count: Arc<Mutex<i32>>,
     url_states: Sender<UrlState>,
 ) {
     loop {
         match url_r.try_recv() {
-            Ok(current) => {
+            Ok((old, current)) => {
                 {
                     let mut active_count = active_count.lock().unwrap();
                     *active_count += 1;
@@ -63,10 +63,10 @@ fn crawl_worker_thread(
                 }
 
                 // TODO: we are fetching the URL twice, which is silly.
-                let state = url_status(&domain, &current);
+                let state = url_status(&domain, &old, &current);
 
                 // Fetch accessible URLs on the same domain and crawl them too.
-                if let UrlState::Accessible(ref url) = state.clone() {
+                if let UrlState::Accessible(_, ref url) = state.clone() {
                     if url.domain() == Some(&domain) {
                         // Lock `visited` and see if we've already visited these discovered URLs.
                         let mut visited = visited.lock().unwrap();
@@ -74,7 +74,7 @@ fn crawl_worker_thread(
                         for new_url in fetch_all_urls(&url) {
                             if !visited.contains(&new_url) {
                                 visited.insert(new_url.clone());
-                                url_s.send(new_url).unwrap();
+                                url_s.send((url.as_str().into(), new_url)).unwrap();
                             }
                         }
                     }
@@ -116,7 +116,9 @@ pub fn crawl(domain: &str, start_url: &Url) -> Crawler {
 
     let (url_state_s, url_state_r) = unbounded();
     let (visit_s, visit_r) = unbounded();
-    visit_s.send(start_url.as_str().into()).unwrap();
+    visit_s
+        .send((start_url.as_str().into(), start_url.as_str().into()))
+        .unwrap();
 
     let crawler = Crawler {
         active_count: active_count.clone(),

--- a/src/fetching.rs
+++ b/src/fetching.rs
@@ -10,11 +10,11 @@ use crate::parsing;
 
 #[derive(Debug, Clone)]
 pub enum UrlState {
-    Accessible(Url),
-    BadStatus(Url, StatusCode),
-    ConnectionFailed(Url),
-    TimedOut(Url),
-    Malformed(String),
+    Accessible(String, Url),
+    BadStatus(String, Url, StatusCode),
+    ConnectionFailed(String, Url),
+    TimedOut(String, Url),
+    Malformed(String, String),
 }
 
 impl fmt::Display for UrlState {
@@ -22,15 +22,21 @@ impl fmt::Display for UrlState {
         let tick = "✔".green();
         let cross = "✘".red();
         match *self {
-            UrlState::Accessible(ref url) => format!("{} {}", tick, url).fmt(f),
-            UrlState::BadStatus(ref url, ref status) => {
-                format!("{} {} ({})", cross, url, status).fmt(f)
+            UrlState::Accessible(ref old_url, ref url) => {
+                format!("{} {} {}", tick, old_url, url).fmt(f)
             }
-            UrlState::ConnectionFailed(ref url) => {
-                format!("{} {} (connection failed)", cross, url).fmt(f)
+            UrlState::BadStatus(ref old_url, ref url, ref status) => {
+                format!("{} {} {} ({})", cross, old_url, url, status).fmt(f)
             }
-            UrlState::TimedOut(ref url) => format!("{} {} (timed out)", cross, url).fmt(f),
-            UrlState::Malformed(ref url) => format!("{} {} (malformed)", cross, url).fmt(f),
+            UrlState::ConnectionFailed(ref old_url, ref url) => {
+                format!("{} {} {} (connection failed)", cross, old_url, url).fmt(f)
+            }
+            UrlState::TimedOut(ref old_url, ref url) => {
+                format!("{} {} {} (timed out)", cross, old_url, url).fmt(f)
+            }
+            UrlState::Malformed(ref old_url, ref url) => {
+                format!("{} {} {} (malformed)", cross, old_url, url).fmt(f)
+            }
         }
     }
 }
@@ -43,11 +49,12 @@ fn build_url(domain: &str, path: &str) -> Result<Url, ParseError> {
 
 const TIMEOUT_SECS: u64 = 10;
 
-pub fn url_status(domain: &str, path: &str) -> UrlState {
+pub fn url_status(domain: &str, old_path: &str, path: &str) -> UrlState {
     match build_url(domain, path) {
         Ok(url) => {
             let (s, r) = unbounded();
             let url2 = url.clone();
+            let old_path_static = old_path.to_owned();
 
             // Try to do the request.
             thread::spawn(move || {
@@ -56,23 +63,23 @@ pub fn url_status(domain: &str, path: &str) -> UrlState {
                 let _ = s.send(match response {
                     Ok(response) => {
                         if response.status().is_success() {
-                            UrlState::Accessible(url)
+                            UrlState::Accessible(old_path_static, url)
                         } else {
                             // TODO: allow redirects unless they're circular
-                            UrlState::BadStatus(url, response.status())
+                            UrlState::BadStatus(old_path_static, url, response.status())
                         }
                     }
-                    Err(_) => UrlState::ConnectionFailed(url),
+                    Err(_) => UrlState::ConnectionFailed(old_path_static, url),
                 });
             });
 
             // Return the request result, or timeout.
             select! {
                 recv(r) -> msg => msg.unwrap(),
-                default(Duration::from_secs(TIMEOUT_SECS)) => UrlState::TimedOut(url2)
+                default(Duration::from_secs(TIMEOUT_SECS)) => UrlState::TimedOut(old_path.to_owned(), url2)
             }
         }
-        Err(_) => UrlState::Malformed(path.to_owned()),
+        Err(_) => UrlState::Malformed(old_path.to_owned(), path.to_owned()),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
 
     for url_state in crawling::crawl(&domain, &start_url) {
         match url_state {
-            UrlState::Accessible(_) => {
+            UrlState::Accessible(_, _) => {
                 success_count += 1;
             }
             status => {


### PR DESCRIPTION
This tool worked really great. But to find the links I needed to corrected I thought it would be helpful to display that URL. 

Here is some example output:

```
$ cargo run http://www.wilfred.me.uk
    Finished dev [unoptimized + debuginfo] target(s) in 0.40s
     Running `target/debug/linkdoc 'http://www.wilfred.me.uk'`
✘ http://www.wilfred.me.uk/ http://cdn.mathjax.org/ (403 Forbidden)
✘ http://www.wilfred.me.uk/blog/2019/03/24/the-siren-song-of-little-languages/ http://shenlanguage.org/shendoc.htm#Kl (404 Not Found)
…
```